### PR TITLE
Add form_classes parameter to /FormTools/Form component

### DIFF
--- a/html/FormTools/Form
+++ b/html/FormTools/Form
@@ -10,6 +10,7 @@ $enable_persisting   => 1
 $forbid_persisting   => {}
 $form_id             => undef
 $form_name           => undef
+$form_classes        => ''
 $self_service        => 0
 </%args>
 <%init>
@@ -111,6 +112,7 @@ $next_for_validation ||= $m->caller(1)->path;
     enctype="multipart/form-data"
     <% defined $form_id ? ' id="'.$form_id.'"' : '' |n %>
     <% defined $form_name ? ' name="'.$form_name.'"' : '' |n %>
+    class="<% $form_classes %>"
 >
 % if ($validation) {
 <input type="hidden" name="_form_tools_next" value="<%$next%>" />


### PR DESCRIPTION
Allow setting of the HTML class attribute for the Form of FormTools.