### PR TITLE
Validate form name

### DIFF
--- a/bin/rt-insert-formtools-config.in
+++ b/bin/rt-insert-formtools-config.in
@@ -29,6 +29,10 @@ unless ( $OPT{'form-name'} ) {
     die "form-name is required to name the new form";
 }
 
+unless ($OPT{'form-name'} =~ /^[\w\s]+$/) {
+    die 'Invalid form name (can only contain letters, numbers, underscore, and spaces)';
+}
+
 my ($filename) = @ARGV;
 die "Not a file: $filename\n" unless -f $filename;
 die "Cannot read file: $filename\n" unless -r $filename;

--- a/html/Admin/FormTools/Advanced.html
+++ b/html/Admin/FormTools/Advanced.html
@@ -69,7 +69,9 @@ if ( $Update ) {
 
     if ( $ARGS{Description} ) {
 
-        if ( $ARGS{Description} ne $form_attribute->Description ) {
+        if ($ARGS{Description} !~ /^[\w\s]+$/) {
+            push @results, loc('Invalid form name (can only contain letters, numbers, underscore, and spaces): [_1]', $ARGS{Description});
+        } elsif ( $ARGS{Description} ne $form_attribute->Description ) {
             my $attr = RT::Attribute->new( RT->SystemUser );
             my ($ret) = $attr->LoadByCols( Name => 'FormTools Form', Description => $ARGS{Description} );
             if ($ret) {

--- a/html/Admin/FormTools/Create.html
+++ b/html/Admin/FormTools/Create.html
@@ -30,37 +30,44 @@ if ( $Create ) {
     push @results, loc('Missing Queue') unless $Queue;
 
     if ( $Description && $Queue ) {
-        my $form = RT::Attribute->new( $session{CurrentUser} );
-        my ($ret) = $form->LoadByCols( Name => 'FormTools Form', Description => $Description );
-        if ($ret) {
-            push @results, loc( 'Name [_1] already exists', $Description );
-        }
 
-        my $queue_obj = RT::Queue->new( $session{CurrentUser} );
-        $queue_obj->Load($Queue);
-        if ( !$queue_obj->Id ) {
-            push @results, loc( 'Invalid queue [_1]', $Queue );
-        }
+        if ( $Description =~ /^[\w\s]+$/ ) {
 
-        # It indicates something wrong if @results is not empty
-        if ( !@results ) {
-            my ( $ret, $msg ) = $form->Create(
-                Name        => 'FormTools Form',
-                Description => $ARGS{Description},
-                Object      => RT->System,
-                Content     => { queue => $queue_obj->Name },
-            );
-
+            my $form = RT::Attribute->new( $session{CurrentUser} );
+            my ($ret) = $form->LoadByCols( Name => 'FormTools Form', Description => $Description );
             if ($ret) {
-                MaybeRedirectForResults(
-                    Actions   => [ loc('Created form [_1]', $Description) ],
-                    Path      => '/Admin/FormTools/Modify.html',
-                    Arguments => { id => $form->Id },
+                push @results, loc( 'Name [_1] already exists', $Description );
+            }
+
+            my $queue_obj = RT::Queue->new( $session{CurrentUser} );
+            $queue_obj->Load($Queue);
+            if ( !$queue_obj->Id ) {
+                push @results, loc( 'Invalid queue [_1]', $Queue );
+            }
+
+            # It indicates something wrong if @results is not empty
+            if ( !@results ) {
+                my ( $ret, $msg ) = $form->Create(
+                    Name        => 'FormTools Form',
+                    Description => $ARGS{Description},
+                    Object      => RT->System,
+                    Content     => { queue => $queue_obj->Name },
                 );
+
+                if ($ret) {
+                    MaybeRedirectForResults(
+                        Actions   => [ loc('Created form [_1]', $Description) ],
+                        Path      => '/Admin/FormTools/Modify.html',
+                        Arguments => { id => $form->Id },
+                    );
+                }
+                else {
+                    push @results, loc( "Couldn't create the form: [_1]", $msg );
+                }
             }
-            else {
-                push @results, loc( "Couldn't create the form: [_1]", $msg );
-            }
+
+        } else {
+            push @results, loc("Invalid form name (can only contain letters, numbers, underscore, and spaces): [_1]", $Description);
         }
     }
 

--- a/po/formtools.pot
+++ b/po/formtools.pot
@@ -57,11 +57,11 @@ msgid "Could not update description: %1"
 msgstr ""
 
 #. ($msg)
-#: html/Admin/FormTools/Create.html:62
+#: html/Admin/FormTools/Create.html:65
 msgid "Couldn't create the form: %1"
 msgstr ""
 
-#: html/Admin/FormTools/Advanced.html:95 html/Admin/FormTools/Modify.html:688
+#: html/Admin/FormTools/Advanced.html:97 html/Admin/FormTools/Modify.html:688
 msgid "Couldn't decode JSON"
 msgstr ""
 
@@ -76,12 +76,12 @@ msgid "Couldn't enable %1: %2"
 msgstr ""
 
 #. ($msg)
-#: html/Admin/FormTools/Advanced.html:105 html/Admin/FormTools/Modify.html:673 html/Admin/FormTools/Modify.html:722
+#: html/Admin/FormTools/Advanced.html:107 html/Admin/FormTools/Modify.html:673 html/Admin/FormTools/Modify.html:722
 msgid "Couldn't update content: %1"
 msgstr ""
 
 #. ($msg)
-#: html/Admin/FormTools/Advanced.html:84
+#: html/Admin/FormTools/Advanced.html:86
 msgid "Couldn't update name: %1"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgid "Create, modify and disable forms"
 msgstr ""
 
 #. ($Description)
-#: html/Admin/FormTools/Create.html:56
+#: html/Admin/FormTools/Create.html:59
 msgid "Created form %1"
 msgstr ""
 
@@ -197,8 +197,14 @@ msgstr ""
 msgid "Invalid JSON"
 msgstr ""
 
+#. ($ARGS{Description})
+#. ($Description)
+#: html/Admin/FormTools/Advanced.html:73 html/Admin/FormTools/Create.html:70
+msgid "Invalid form name (can only contain letters, numbers, underscore, and spaces): %1"
+msgstr ""
+
 #. ($Queue)
-#: html/Admin/FormTools/Create.html:42
+#: html/Admin/FormTools/Create.html:45
 msgid "Invalid queue %1"
 msgstr ""
 
@@ -210,7 +216,7 @@ msgstr ""
 msgid "Left"
 msgstr ""
 
-#: html/Admin/FormTools/Advanced.html:90 html/Admin/FormTools/Create.html:29
+#: html/Admin/FormTools/Advanced.html:92 html/Admin/FormTools/Create.html:29
 msgid "Missing Name"
 msgstr ""
 
@@ -251,7 +257,7 @@ msgstr ""
 
 #. ($ARGS{Description})
 #. ($Description)
-#: html/Admin/FormTools/Advanced.html:76 html/Admin/FormTools/Create.html:36
+#: html/Admin/FormTools/Advanced.html:78 html/Admin/FormTools/Create.html:39
 msgid "Name %1 already exists"
 msgstr ""
 
@@ -295,7 +301,7 @@ msgstr ""
 msgid "Require if"
 msgstr ""
 
-#: html/FormTools/Field:165 html/FormTools/Field:354
+#: html/FormTools/Field:165 html/FormTools/Field:358
 msgid "Required"
 msgstr ""
 
@@ -347,7 +353,7 @@ msgstr ""
 msgid "Update"
 msgstr ""
 
-#: html/Admin/FormTools/Advanced.html:102 html/Admin/FormTools/Modify.html:670 html/Admin/FormTools/Modify.html:719
+#: html/Admin/FormTools/Advanced.html:104 html/Admin/FormTools/Modify.html:670 html/Admin/FormTools/Modify.html:719
 msgid "Updated content"
 msgstr ""
 
@@ -355,7 +361,7 @@ msgstr ""
 msgid "Updated description"
 msgstr ""
 
-#: html/Admin/FormTools/Advanced.html:81
+#: html/Admin/FormTools/Advanced.html:83
 msgid "Updated name"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -65,11 +65,11 @@ msgid "Could not update description: %1"
 msgstr "Impossible de mettre à jour la description: %1"
 
 #. ($msg)
-#: html/Admin/FormTools/Create.html:62
+#: html/Admin/FormTools/Create.html:65
 msgid "Couldn't create the form: %1"
 msgstr "Impossible de créer le formulaire: %1"
 
-#: html/Admin/FormTools/Advanced.html:95 html/Admin/FormTools/Modify.html:688
+#: html/Admin/FormTools/Advanced.html:97 html/Admin/FormTools/Modify.html:688
 msgid "Couldn't decode JSON"
 msgstr "Impossible de décoder le JSON"
 
@@ -84,12 +84,12 @@ msgid "Couldn't enable %1: %2"
 msgstr "Impossible d'activer %1: %2"
 
 #. ($msg)
-#: html/Admin/FormTools/Advanced.html:105 html/Admin/FormTools/Modify.html:673 html/Admin/FormTools/Modify.html:722
+#: html/Admin/FormTools/Advanced.html:107 html/Admin/FormTools/Modify.html:673 html/Admin/FormTools/Modify.html:722
 msgid "Couldn't update content: %1"
 msgstr "Impossible de mettre à jour le contenu: %1"
 
 #. ($msg)
-#: html/Admin/FormTools/Advanced.html:84
+#: html/Admin/FormTools/Advanced.html:86
 msgid "Couldn't update name: %1"
 msgstr "Impossible de mettre à jour le nom: %1"
 
@@ -106,7 +106,7 @@ msgid "Create, modify and disable forms"
 msgstr "Créer, modifier et désactiver les formulaires"
 
 #. ($Description)
-#: html/Admin/FormTools/Create.html:56
+#: html/Admin/FormTools/Create.html:59
 msgid "Created form %1"
 msgstr "Formulaire %1 créé"
 
@@ -205,8 +205,14 @@ msgstr "Inclure les formulaires désactivés dans la liste."
 msgid "Invalid JSON"
 msgstr "JSON invalide"
 
+#. ($ARGS{Description})
+#. ($Description)
+#: html/Admin/FormTools/Advanced.html:73 html/Admin/FormTools/Create.html:70
+msgid "Invalid form name (can only contain letters, numbers, underscore, and spaces): %1"
+msgstr "Nom de formulaire invalide (ne peut contenir que des lettres, des chiffres, des traits de soulignement et des espaces): %1"
+
 #. ($Queue)
-#: html/Admin/FormTools/Create.html:42
+#: html/Admin/FormTools/Create.html:45
 msgid "Invalid queue %1"
 msgstr "File %1 invalide"
 
@@ -218,7 +224,7 @@ msgstr "Libellé"
 msgid "Left"
 msgstr "Gauche"
 
-#: html/Admin/FormTools/Advanced.html:90 html/Admin/FormTools/Create.html:29
+#: html/Admin/FormTools/Advanced.html:92 html/Admin/FormTools/Create.html:29
 msgid "Missing Name"
 msgstr "Nom manquant"
 
@@ -259,7 +265,7 @@ msgstr "Nom"
 
 #. ($ARGS{Description})
 #. ($Description)
-#: html/Admin/FormTools/Advanced.html:76 html/Admin/FormTools/Create.html:36
+#: html/Admin/FormTools/Advanced.html:78 html/Admin/FormTools/Create.html:39
 msgid "Name %1 already exists"
 msgstr "Le nom %1 existe déjà"
 
@@ -303,7 +309,7 @@ msgstr "Requis"
 msgid "Require if"
 msgstr "Requis si"
 
-#: html/FormTools/Field:165 html/FormTools/Field:354
+#: html/FormTools/Field:165 html/FormTools/Field:358
 msgid "Required"
 msgstr "Requis"
 
@@ -355,7 +361,7 @@ msgstr "Impossible de définir l'icône du formulaire"
 msgid "Update"
 msgstr "Mettre à jour"
 
-#: html/Admin/FormTools/Advanced.html:102 html/Admin/FormTools/Modify.html:670 html/Admin/FormTools/Modify.html:719
+#: html/Admin/FormTools/Advanced.html:104 html/Admin/FormTools/Modify.html:670 html/Admin/FormTools/Modify.html:719
 msgid "Updated content"
 msgstr "Contenu mis à jour"
 
@@ -363,7 +369,7 @@ msgstr "Contenu mis à jour"
 msgid "Updated description"
 msgstr "Description mise à jour"
 
-#: html/Admin/FormTools/Advanced.html:81
+#: html/Admin/FormTools/Advanced.html:83
 msgid "Updated name"
 msgstr "Nom mis à jour"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -209,7 +209,7 @@ msgstr "JSON invalide"
 #. ($Description)
 #: html/Admin/FormTools/Advanced.html:73 html/Admin/FormTools/Create.html:70
 msgid "Invalid form name (can only contain letters, numbers, underscore, and spaces): %1"
-msgstr "Nom de formulaire invalide (ne peut contenir que des lettres, des chiffres, des traits de soulignement et des espaces): %1"
+msgstr "Nom de formulaire invalide (ne peut contenir que des lettres, des chiffres, des tirets du bas et des espaces): %1"
 
 #. ($Queue)
 #: html/Admin/FormTools/Create.html:45


### PR DESCRIPTION
Hello,

This PR for validate form name before create, update or insert form

For example, I am currently authorised to create a form called "test-form" but it cannot be loaded because its name contains "-". 