### PR TITLE
Make labeled value consistent

### DIFF
--- a/html/FormTools/Field
+++ b/html/FormTools/Field
@@ -171,7 +171,7 @@ $default = '' unless defined $default;
 <&| /Elements/LabeledValue,
     RawLabel       => $m->interp->apply_escapes($field_label, 'h') . $after_label,
     LabelSpanClass => $tooltip ? 'prev-icon-helper' : '',
-    LabelTooltip   => $tooltip
+    LabelTooltip   => $tooltip,
 &>
   <div data-name="<% $cf ? $cf->Name : '' %>"
 % if ( $ARGS{validation} ) {

--- a/html/FormTools/Field
+++ b/html/FormTools/Field
@@ -169,7 +169,7 @@ $default = '' unless defined $default;
 % if ($render_as ne 'hidden' && $show_label) { # no label if hidden
 
 <&| /Elements/LabeledValue,
-    RawLabel       => $m->interp->apply_escapes($field_label, 'h') . $after_label,
+    RawLabel       => $m->interp->apply_escapes($field_label, 'h') . ':' . $after_label,
     LabelSpanClass => $tooltip ? 'prev-icon-helper' : '',
     LabelTooltip   => $tooltip,
 &>

--- a/html/FormTools/Field
+++ b/html/FormTools/Field
@@ -168,7 +168,11 @@ $default = '' unless defined $default;
 
 % if ($render_as ne 'hidden' && $show_label) { # no label if hidden
 
-<&| /Elements/LabeledValue, RawLabel => $m->interp->apply_escapes($field_label, 'h') . $after_label, LabelSpanClass => $tooltip ? 'prev-icon-helper' : '', LabelTooltip => $tooltip &>
+<&| /Elements/LabeledValue,
+    RawLabel       => $m->interp->apply_escapes($field_label, 'h') . $after_label,
+    LabelSpanClass => $tooltip ? 'prev-icon-helper' : '',
+    LabelTooltip   => $tooltip
+&>
   <div data-name="<% $cf ? $cf->Name : '' %>"
 % if ( $ARGS{validation} ) {
     data-validation="<% $ARGS{validation} %>"


### PR DESCRIPTION
BPS,

When using the following component call:

    <& /FormTools/Field,
        name => 'Foo',
    &>

there is no colon between the label and the field input - which the rest of RT seems to use.

This PR addresses that inconsistency.