### PR TITLE
Add callback after custom fields are validated to allow additional validation

### DIFF
--- a/html/FormTools/Form
+++ b/html/FormTools/Form
@@ -68,6 +68,8 @@ if ($real_next) {
         push @results, @msg;
     }
 
+    $m->callback( CallbackName => 'AfterValidateCustomFields', ARGSRef => \%request_args, results => \@results );
+
     unless ( @results || ( $request_args{AddMoreAttach} && $request_args{AddMoreAttach} eq 'Add More Files' ) ) {
         # Flag to show validation passed
         $ARGS{'validation_ok'} = 1;


### PR DESCRIPTION
Currently there's no way to do any validation on core fields. This can be used to do additional validation on any field. In my case, I'm using it to ensure any Cc that is added is an internal email address. The regular ticket creation forms already have similar callbacks that can be used to add custom validation of built in fields and show an error before a ticket is created. 

I hope to use this callback in my extension https://github.com/grantemsley/RT-Extension-RestrictEmailDomain